### PR TITLE
Fix links to Jira tickets

### DIFF
--- a/night-reports/obs-tickets.ipynb
+++ b/night-reports/obs-tickets.ipynb
@@ -139,7 +139,7 @@
     "issues_df = issues_df.sort_values(by=[\"created\"])\n",
     "\n",
     "def link_issue(handle):\n",
-    "    return f'<a href=\"https://jira.lsstcorp.org/issues/{handle}\">{handle}</a>'\n",
+    "    return f'<a href=\"https://jira.lsstcorp.org/browse/{handle}\">{handle}</a>'\n",
     "\n",
     "\n",
     "def format_timestamp(dt):\n",


### PR DESCRIPTION
Now using the correct `/browse/{issue}` URL format.