### PR TITLE
Update observation date in almanac notebook

### DIFF
--- a/night-reports/almanac.ipynb
+++ b/night-reports/almanac.ipynb
@@ -24,7 +24,7 @@
    "source": [
     "# Times Square parameters\n",
     "import datetime\n",
-    "dayobs = datetime.date.fromisoformat(\"2024-01-08\")"
+    "dayobs = datetime.date.fromisoformat(\"2026-04-23\")"
    ]
   },
   {


### PR DESCRIPTION
This PR is primarily to test whether webhooks are being processed by Times Square/Noteburst.